### PR TITLE
Fix installing dependencies for Pakket

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -14,7 +14,6 @@ requires 'JSON::MaybeXS';
 requires 'Log::Any', '>= 0.05';
 requires 'Log::Any::Adapter::Dispatch', '>= 0.06';
 requires 'Log::Dispatch';
-requires 'Log::Dispatch::Screen::Gentoo';
 requires 'MetaCPAN::Client';
 requires 'Module::CPANfile';
 requires 'Module::Runtime';
@@ -28,8 +27,20 @@ requires 'System::Command';
 requires 'Types::Path::Tiny';
 requires 'version', '>= 0.77';
 requires 'Archive::Tar::Wrapper';
-requires 'Archive::Any';
 requires 'Digest::SHA';
+
+# This is temporarily disabling official Term::GentooFunctions
+# They use Term::ANSIScreen which fails to install because of Module::Package
+# Instead, we're moving it to lib/ temporarily with copied relevant functions
+# from Term::ANSIScreen
+# RT #123497
+# -- Sawyer X
+# From Term::GentooFunctions
+requires 'Term::ANSIColor';
+requires 'Term::Size';
+# From Log::Dispatch::Screen::Gentoo
+#requires 'Log::Dispatch::Screen::Gentoo';
+requires 'Module::Runtime';
 
 # Optimizes Gentoo color output
 requires 'Unicode::UTF8';

--- a/lib/Log/Dispatch/Screen/Gentoo.pm
+++ b/lib/Log/Dispatch/Screen/Gentoo.pm
@@ -1,0 +1,110 @@
+package Log::Dispatch::Screen::Gentoo;
+# ABSTRACT: Gentoo-colored screen logging output
+
+use strict;
+use warnings;
+use parent 'Log::Dispatch::Screen';
+use Encode ();
+use Module::Runtime qw< require_module >;
+use Term::GentooFunctions ':all';
+
+## no critic qw(Modules::RequireExplicitInclusion)
+my $encode
+    = eval { require Unicode::UTF8; 1; }
+    ? sub { Unicode::UTF8::encode_utf8( $_[0] ) }
+    : sub { Encode::encode_utf8( $_[0] ) };
+
+# einfo
+# ewarn
+# eerror
+# equiet
+# ebegin
+# eend
+
+our %FUNCTION_MAP = (
+    ''          => sub { einfo( $_[0] )  },
+    'debug'     => sub { einfo( $_[0] )  },
+    'info'      => sub { einfo( $_[0] )  },
+    'notice'    => sub { einfo( $_[0] )  },
+    'warning'   => sub { ewarn( $_[0] )  },
+    'error'     => sub { eerror( $_[0] ) },
+    'critical'  => sub { eerror( $_[0] ) },
+    'alert'     => sub { eerror( $_[0] ) },
+    'emergency' => sub { eerror( $_[0] ) },
+);
+
+sub log_message {
+    my ( $self, %p ) = @_;
+
+    my $level = $p{'level'};
+
+    my $message
+        = $self->{'utf8'}
+        ? $encode->( $p{'message'} )
+        : $encode->( $p{'message'} );
+
+    my $print_func = $FUNCTION_MAP{$level} //= $FUNCTION_MAP{''};
+
+    if ( $self->{'stderr'} ) {
+        # Should be STDERR
+        $print_func->($message);
+    } else {
+        # Should be STDOUT
+        $print_func->($message);
+    }
+}
+
+1;
+
+__END__
+
+=pod
+
+=head1 SYNOPSIS
+
+    use Log::Dispatch;
+
+    my $log = Log::Dispatch->new(
+        'outputs' => [
+            [
+                'Screen::Gentoo',
+                'min_level' => 'debug',
+                'stderr'    => 1,
+                'newline'   => 1,
+            ],
+        ],
+    );
+
+    $log->info('Information');
+    $log->warning('Uh oh!');
+    $log->critical('No oh!');
+
+=head1 DESCRIPTION
+
+This implements a colorful output that uses L<Term::GentooFunctions> to
+print out the output.
+
+It also works with indentation when using C<eindent> and C<eoutdent> from
+L<Term::GentooFunctions>.
+
+If you have L<Unicode::UTF8> available, it will use that to support UTF-8
+character encodings. (This is much faster than L<Encode>.)
+
+One limitation this has is that there are only three colors, which means
+that you cannot see a difference between levels C<debug>, C<notice>, and
+C<info> which all have a green color, or between C<error>, C<critical>,
+C<alert>, and C<emergency> which all have a red color.
+
+At least for now.
+
+=head1 SEE ALSO
+
+=over 4
+
+=item * L<Log::Dispatch::Screen::Color>
+
+Colors entire lines, not just the beginning. Try it out.
+
+=item * L<Unicode::UTF8>
+
+=back

--- a/lib/Term/GentooFunctions.pm
+++ b/lib/Term/GentooFunctions.pm
@@ -1,0 +1,172 @@
+package Term::GentooFunctions;
+
+require 5.006001;
+
+use strict;
+use utf8;
+
+BEGIN {
+    eval "use Term::Size;";               my $old = $@;
+    eval "use Term::Size::Win32" if $old; my $new = $@;
+    die $old if $old and $new;
+    die $new if $new;
+}
+
+use Exporter;
+use Term::ANSIColor qw(:constants);
+use Term::ANSIScreen qw(:cursor);
+
+our $VERSION = '1.3607';
+
+our @EXPORT_OK = qw(einfo eerror ewarn ebegin eend eindent eoutdent einfon edie edo start_spinner step_spinner end_spinner equiet);
+our %EXPORT_TAGS = (all=>[@EXPORT_OK]);
+
+use base qw(Exporter);
+
+BEGIN {
+    # use Data::Dumper;
+    # die Dumper(\%ENV) unless defined $ENV{RC_INDENTATION};
+    $ENV{RC_DEFAULT_INDENT} = 2  unless defined $ENV{RC_DEFAULT_INDENT};
+    $ENV{RC_INDENTATION}    = "" unless defined $ENV{RC_INDENTATION};
+}
+
+my $quiet;
+sub equiet {
+    $quiet = $_[0] if @_;
+    return $quiet;
+}
+
+sub edie(@) {
+    my $msg = (@_>0 ? shift : $_);
+    eerror($msg);
+    eend(0);
+    exit 0x65;
+}
+
+sub einfon($) {
+    my $msg = wash(shift);
+
+    return if $quiet;
+
+    local $| = 1;
+    print " ", BOLD, GREEN, "*", RESET, $msg;
+}
+
+sub eindent()  {
+    my $i = shift || $ENV{RC_DEFAULT_INDENT};
+
+    $ENV{RC_INDENTATION} .= " " x $i;
+}
+
+sub eoutdent() {
+    my $i = shift || $ENV{RC_DEFAULT_INDENT};
+
+    $ENV{RC_INDENTATION} =~ s/ // for 1 .. $i;
+}
+
+sub wash($) {
+    my $msg = shift;
+       $msg =~ s/^\s+//s;
+
+    chomp $msg;
+    return "$ENV{RC_INDENTATION} $msg";
+}
+
+sub einfo($) {
+    my $msg = wash(shift);
+
+    return if $quiet;
+    print " ", BOLD, GREEN, "*", RESET, "$msg\n";
+}
+
+sub ebegin($) {
+    goto &einfo;
+}
+
+sub eerror($) {
+    my $msg = wash(shift);
+
+    return if $quiet;
+    print " ", BOLD, RED, "*", RESET, "$msg\n";
+}
+
+sub ewarn($) {
+    my $msg = wash(shift);
+
+    return if $quiet;
+    print " ", BOLD, YELLOW, "*", RESET, "$msg\n";
+}
+
+sub eend(@) {
+    my $res = (@_>0 ? shift : $_);
+
+    return if $quiet;
+
+    my ($columns, $rows) = eval 'Term::Size::chars *STDOUT{IO}';
+       ($columns, $rows) = eval 'Term::Size::Win32::chars *STDOUT{IO}' if $@;
+
+    die "couldn't find a term size function to use" if $@;
+
+    print up(1), right($columns - 6), BOLD, BLUE, "[ ", 
+        ($res ?  GREEN."ok" : RED."!!"), 
+        BLUE, " ]", RESET, "\n";
+
+    $res;
+}
+
+sub edo($&) {
+    my ($begin_msg, $code) = @_;
+
+    ebegin $begin_msg;
+    eindent;
+    my ($cr, @cr);
+
+    my $wa = wantarray;
+    my $r = eval { if( $wa ) { @cr = $code->() } else { $cr = $code->() } 1 };
+    edie $@ unless $r;
+
+    eoutdent;
+    eend 1;
+
+    return @cr if $wa;
+    return $cr;
+}
+
+{
+    my $spinner_state;
+    my $spinner_msg;
+    sub start_spinner($) {
+        my $msg = wash(shift);
+
+        $spinner_state = "-";
+        $spinner_msg = $msg;
+
+        einfon $spinner_msg;
+    }
+
+    my $spinext = {"-"=>'\\', '\\'=>'|', "|"=>"/", "/"=>"-"};
+    sub step_spinner(;$) {
+        # NOTE: really I should use savepost and clline from ANSIScreen, but he doesn't have [0G at all.  Meh
+
+        return if $quiet;
+        print "\e[0G\e[K";
+
+        if( $_[0] ) {
+            einfon("$spinner_msg $spinner_state ... $_[0]");
+
+        } else {
+            einfon("$spinner_msg $spinner_state ");
+        }
+
+        $spinner_state = $spinext->{$spinner_state};
+    }
+
+    sub end_spinner($) {
+        return if $quiet;
+        print "\e[0G\e[K";
+        einfo $spinner_msg;
+        goto &eend;
+    }
+}
+
+"this file is true";

--- a/lib/Term/GentooFunctions.pm
+++ b/lib/Term/GentooFunctions.pm
@@ -14,7 +14,7 @@ BEGIN {
 
 use Exporter;
 use Term::ANSIColor qw(:constants);
-use Term::ANSIScreen qw(:cursor);
+#use Term::ANSIScreen qw(:cursor);
 
 our $VERSION = '1.3607';
 
@@ -22,6 +22,76 @@ our @EXPORT_OK = qw(einfo eerror ewarn ebegin eend eindent eoutdent einfon edie 
 our %EXPORT_TAGS = (all=>[@EXPORT_OK]);
 
 use base qw(Exporter);
+
+# Lifted from Term::ANSIScreen (RT #123497)
+# -- Sawyer X
+our $AUTORESET;
+my %attributes = (
+    'clear'      => 0,    'reset'      => 0,
+    'bold'       => 1,    'dark'       => 2,
+    'underline'  => 4,    'underscore' => 4,
+    'blink'      => 5,    'reverse'    => 7,
+    'concealed'  => 8,
+ 
+    'black'      => 30,   'on_black'   => 40,
+    'red'        => 31,   'on_red'     => 41,
+    'green'      => 32,   'on_green'   => 42,
+    'yellow'     => 33,   'on_yellow'  => 43,
+    'blue'       => 34,   'on_blue'    => 44,
+    'magenta'    => 35,   'on_magenta' => 45,
+    'cyan'       => 36,   'on_cyan'    => 46,
+    'white'      => 37,   'on_white'   => 47,
+);
+
+my %sequences = (
+    'up'        => '?A',      'down'      => '?B',
+    'right'     => '?C',      'left'      => '?D',
+    'savepos'   => 's',       'loadpos'   => 'u',
+    'cls'       => '2J',      'clline'    => 'K',
+    'cldown'    => '0J',      'clup'      => '1J',
+    'locate'    => '?;?H',    'setmode'   => '?h',
+    'wrapon'    => '7h',      'wrapoff'   => '7l',
+    'setscroll' => '?;?r',
+);
+
+# Lifted and adjusted from Term::ANSIScreen (RT #123497)
+# -- Sawyer X
+BEGIN {
+    my $enable_colors = !defined $ENV{ANSI_COLORS_DISABLED};
+    no strict 'refs';
+    no warnings 'uninitialized';
+
+    foreach my $sub ( keys %sequences ) {
+        my $seq = $sequences{$sub};
+        *{"Term::GentooFunctions::$sub"} = sub {
+            return '' unless $enable_colors;
+     
+            $seq =~ s/\?/defined($_[0]) ? shift(@_) : 1/eg;
+            return((defined wantarray) ? "\e[$seq"
+                                       : print("\e[$seq"));
+        };
+    }
+
+    foreach my $sub ( keys %attributes ) {
+        my $attr = $attributes{lc($sub)};
+        my $sub_name = uc($sub);
+        *{"Term::GentooFunctions::$sub_name"} = sub {
+            if (defined($attr) and $sub =~ /^[A-Z_]+$/) {
+                my $out = "@_";
+                if ($enable_colors) {
+                    $out = "\e[${attr}m" . $out;
+                    $out .= "\e[0m" if ($AUTORESET and @_ and $out !~ /\e\[0m$/s);
+                }
+                return((defined wantarray) ? $out
+                                           : print($out));
+            }
+            else {
+                require Carp;
+                Carp::croak("Undefined subroutine &$sub ($sub_name) called");
+            }
+        }
+    }
+}
 
 BEGIN {
     # use Data::Dumper;


### PR DESCRIPTION
Pull in Term::GentooFunctions (and dispatcher) into Pakket tree:

This is the first part of fixing the Term::GentooFunctions situation,
explained here. It also includes Log::Dispatch::Screen::Gentoo which
depends on it.

Term::GentooFunctions uses Term::ANSIScreen to control the cursor.
Term::ANSIScreen in turn uses Module::Package which has its own entire
installation problem. Term::ANSIScreen was maintained by Audry and will
not see a new version in time soon. This would require
Term::GentooFunctions to release a new version too.

What I'm doing here is copying over Term::GentooFunctions into the
Pakket tree, then adding the functions missing from Term::ANSIScreen.

I recommended this for a new version of Term::GentooFunctions here:

https://rt.cpan.org/Ticket/Display.html?id=123497

Once a new version is released, we will upgrade to it. Over time we
might also just remove this requirement.