### PR TITLE
Add 'v' in front of three numbers versions for perl packages

### DIFF
--- a/lib/Pakket/Package.pm
+++ b/lib/Pakket/Package.pm
@@ -6,6 +6,7 @@ use MooseX::StrictConstructor;
 use Pakket::Types;
 use Pakket::Constants qw< PAKKET_DEFAULT_RELEASE >;
 use JSON::MaybeXS qw< decode_json >;
+use version 0.77;
 
 with qw< Pakket::Role::BasicPackageAttrs >;
 
@@ -54,6 +55,16 @@ has 'runtime_prereqs' => (
     'lazy'    => 1,
     'builder' => '_build_runtime_prereqs',
 );
+
+sub BUILDARGS {
+    my ( $class, %args ) = @_;
+    if ($args{'category'} eq 'perl') {
+        my $ver = version->new($args{'version'});
+        if ($ver->is_qv) {$ver = version->new($ver->normal)};
+        $args{'version'} = $ver->stringify();
+    }
+    return \%args;
+}
 
 sub _build_configure_prereqs {
     my $self    = shift;

--- a/lib/Pakket/PackageQuery.pm
+++ b/lib/Pakket/PackageQuery.pm
@@ -6,6 +6,7 @@ use MooseX::StrictConstructor;
 
 use Carp              qw< croak >;
 use Log::Any          qw< $log >;
+use version 0.77;
 use Pakket::Constants qw<
     PAKKET_PACKAGE_SPEC
     PAKKET_DEFAULT_RELEASE
@@ -32,6 +33,16 @@ has 'is_bootstrap' => (
     'isa'     => 'Bool',
     'default' => sub {0},
 );
+
+sub BUILDARGS {
+    my ( $class, %args ) = @_;
+    if ($args{'category'} eq 'perl') {
+        my $ver = version->new($args{'version'});
+        if ($ver->is_qv) {$ver = version->new($ver->normal)};
+        $args{'version'} = $ver->stringify();
+    }
+    return \%args;
+}
 
 sub new_from_string {
     my ( $class, $req_str ) = @_;


### PR DESCRIPTION
This is how work Metacpan API and CPAN::Meta::Requirements.
If version of perl package has three numbers, it puts 'v' in front
(if 'v' doesn't exist).
https://metacpan.org/source/DAGOLDEN/CPAN-Meta-Requirements-2.140/lib/CPAN/Meta/Requirements.pm#L154

Pakket should repeat this behavior for perl versions.