### PR TITLE
Revamp command line interface for "manage" command

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -496,7 +496,7 @@ equivalent_modules = Moo Moo::Role
 
 # 0.0.9
 [Perlsecret]
-allow_secrets = Bang Bang, Venus, Winking Fat Comma, Enterprise
+allow_secrets = Bang Bang, Venus, Winking Fat Comma, Enterprise, Baby Cart
 
 #--------------------------------------
 # - Perl::Critic::Policy::HTTPCookies -

--- a/lib/Pakket.pm
+++ b/lib/Pakket.pm
@@ -12,7 +12,7 @@ __END__
 
 =head1 DESCRIPTION
 
-Pakket is a meta-packaging system that allows you to manage your system
+Pakket is a meta-packaging system that allows you to manage
 dependencies. It works by trying to avoid work.
 
 =head2 What can you do with Pakket?

--- a/lib/Pakket/CLI/Command/manage.pm
+++ b/lib/Pakket/CLI/Command/manage.pm
@@ -188,7 +188,7 @@ sub _validate_repos {
 
 sub _validate_arg_command {
     my $self     = shift;
-    my @cmd_list = keys %commands;
+    my @cmd_list = sort keys %commands;
 
     my $command = shift @{ $self->{'args'} }
         or $self->usage_error( "Must pick action (@{[ join '/', @cmd_list ]})" );

--- a/lib/Pakket/CLI/Command/manage.pm
+++ b/lib/Pakket/CLI/Command/manage.pm
@@ -21,8 +21,14 @@ use Pakket::Constants qw<
     PAKKET_VALID_PHASES
 >;
 
-sub abstract    { 'Scaffold a project' }
-sub description { 'Scaffold a project' }
+sub abstract    { 'Manage Pakket packages and repositories' }
+sub description { return <<'_END_DESC';
+This command manages Pakket packages across repositories.
+It allows you to add new specs, sources, and packages, as well
+as edit existing ones, and view your repositories.
+_END_DESC
+}
+
 
 sub opt_spec {
     return (

--- a/lib/Pakket/CLI/Command/manage.pm
+++ b/lib/Pakket/CLI/Command/manage.pm
@@ -32,7 +32,7 @@ _END_DESC
 my %commands = map +( $_ => 1 ), qw<
     add-package
     remove-package
-    list-package
+    show-package
     remove-parcel
     add-deps
     list-deps
@@ -127,7 +127,7 @@ sub execute {
         'list-specs'     => sub { $manager->list_ids('spec'); },
         'list-sources'   => sub { $manager->list_ids('source'); },
         'list-parcels'   => sub { $manager->list_ids('parcel'); },
-        'list-package'   => sub { $manager->show_package_config; },
+        'show-package'   => sub { $manager->show_package_config; },
         'list-deps'      => sub { $manager->show_package_deps; },
     );
 
@@ -154,7 +154,7 @@ sub _validate_repos {
         'add-package'    => [ 'spec', 'source' ],
         'remove-package' => [ 'spec', 'source' ],
         'remove-parcel'  => [ 'parcel' ],
-        'list-package'   => [ 'spec'   ],
+        'show-package'   => [ 'spec'   ],
         'add-deps'       => [ 'spec'   ],
         'remove-deps'    => [ 'spec'   ],
         'list-deps'      => [ 'spec'   ],
@@ -202,7 +202,7 @@ sub _validate_arg_command {
     $command eq 'remove-package' and $self->_validate_args_remove;    # FIXME: Rename method
     $command eq 'remove-parcel'  and $self->_validate_args_remove_parcel;
     $command eq 'list-deps'      and $self->_validate_args_show_deps; # FIXME: Rename method
-    $command eq 'list-package'   and $self->_validate_args_show;      # FIXME: Rename method
+    $command eq 'show-package'   and $self->_validate_args_show;      # FIXME: Rename method
 
     $command eq 'add-deps' || $command eq 'remove-deps'
        and $self->_validate_args_dependency;
@@ -323,7 +323,7 @@ __END__
 =head1 SYNOPSIS
 
     $ pakket manage add-package perl/Dancer2=0.205000:1
-    $ pakket manage list-package perl/Dancer2=0.205000:1
+    $ pakket manage show-package perl/Dancer2=0.205000:1
     $ pakket manage remove-package perl/Dancer2=0.205000:1
     $ pakket manage remove-parcel perl/Dancer2=0.205000:1
 


### PR DESCRIPTION
I've hated this for a while. It grew in complexity over time and we
never made sure it stays consistent. I think this is a step in the right
direction.

Previously,

* "add", "remove", and "show" were for the package, implicitly.
* Some commands had "list", others add "show".
* Some commands had underscores ("remove_parcel").
* There were sub-subcommands ("pakket manage list parcels").
* Dependency commands were *really* hard to fathom and remember.

Now,

* All commands are either prefixed with "add", "remove", or "list".
* All commands have two parts: verb ("add", "remove", "list") and
  object ("package", "parcel", "deps").
* Dependencies now declare the dependency name using "--on" and the
  phase using "--phase".

That's it.

This is a bit tricky because it includes a layer that translates the
previous interface to the new one so it should work too. No tests, so
good luck to us all. :)