### PR TITLE
Set log file by default as ~/.pakket/pakket.log

### DIFF
--- a/lib/Pakket/Log.pm
+++ b/lib/Pakket/Log.pm
@@ -95,8 +95,19 @@ sub build_logger {
 }
 
 sub _build_logger {
-    my $class = shift;
-    my $file  = shift || Path::Tiny::path('/tmp/build.log')->stringify;
+    my ($class, $file) = @_;
+
+    if (!$file) {
+        my $dir = Path::Tiny::path('~/.pakket');
+        eval {
+            $dir->mkpath;
+            1;
+        } or do {
+            die "Can't create directory $dir : " . $!;
+        };
+
+        $file = $dir->child("pakket.log")->stringify;
+    }
 
     return [
         'File',


### PR DESCRIPTION
There is a problem with permissions for log in /tmp/build.log

Home directory seems more suitable for default logs for any users
to avoid problems with permissions.