### PR TITLE
Enable deleting file before copying in dircopy()

### DIFF
--- a/lib/Pakket/Installer.pm
+++ b/lib/Pakket/Installer.pm
@@ -214,6 +214,7 @@ sub copy_package_to_install_dir {
             and next;
 
         my $target_dir = $dir->child($basename);
+        local $File::Copy::Recursive::RMTrgFil = 1;
         dircopy($item, $target_dir)
             or croak($log->criticalf("Can't copy $item to $target_dir ($!)"));
     }


### PR DESCRIPTION
All installed perl modules have permissions '-r--r--r--'
which breaks dircopy() if file already exists, for example when we
upgrading package or reinstalling it.

We need to enable removing file before copying it in dircopy().