### PR TITLE
Check return code from dircopy()

### DIFF
--- a/lib/Pakket/Installer.pm
+++ b/lib/Pakket/Installer.pm
@@ -214,7 +214,8 @@ sub copy_package_to_install_dir {
             and next;
 
         my $target_dir = $dir->child($basename);
-        dircopy( $item, $target_dir );
+        dircopy($item, $target_dir)
+            or croak($log->criticalf("Can't copy $item to $target_dir ($!)"));
     }
 }
 


### PR DESCRIPTION
Currently if dircopy() failed (because of permissions or something)
pakket successfully keeps installation.