### PR TITLE
Add releases in scaffolder

### DIFF
--- a/lib/Pakket/CLI/Command/manage.pm
+++ b/lib/Pakket/CLI/Command/manage.pm
@@ -289,14 +289,14 @@ sub _validate_args_show_deps {
 sub _read_package_str {
     my ( $self, $spec_str ) = @_;
 
-    my $spec = Pakket::PackageQuery->new_from_string($spec_str);
+    my $package = Pakket::PackageQuery->new_from_string($spec_str);
 
     # add supported categories
-    if ( !( $spec->category eq 'perl' or $spec->category eq 'native' ) ) {
+    if ( !( $package->category eq 'perl' or $package->category eq 'native' ) ) {
         $self->usage_error( "Wrong 'name' format\n" );
     }
 
-    return $spec;
+    return $package;
 }
 
 sub _read_set_package_str {

--- a/lib/Pakket/CLI/Command/manage.pm
+++ b/lib/Pakket/CLI/Command/manage.pm
@@ -14,7 +14,6 @@ use Pakket::Log;
 use Pakket::Config;
 use Pakket::Manager;
 use Pakket::PackageQuery;
-use Pakket::Requirement;
 use Pakket::Utils::Repository qw< gen_repo_config >;
 use Pakket::Constants qw<
     PAKKET_PACKAGE_SPEC
@@ -290,13 +289,7 @@ sub _validate_args_show_deps {
 sub _read_package_str {
     my ( $self, $spec_str ) = @_;
 
-    my $spec;
-    if ( $self->{'command'} eq 'add-package' ) {
-        my ( $c, $n, $v ) = $spec_str =~ PAKKET_PACKAGE_SPEC();
-        !defined $v and $spec = Pakket::Requirement->new( category => $c, name => $n );
-    }
-
-    $spec //= Pakket::PackageQuery->new_from_string($spec_str);
+    my $spec = Pakket::PackageQuery->new_from_string($spec_str);
 
     # add supported categories
     if ( !( $spec->category eq 'perl' or $spec->category eq 'native' ) ) {

--- a/lib/Pakket/CLI/Command/manage.pm
+++ b/lib/Pakket/CLI/Command/manage.pm
@@ -95,7 +95,7 @@ sub execute {
         cpanfile        => $self->{'cpanfile'},
         cache_dir       => $self->{'cache_dir'},
         phases          => $self->{'gen_phases'},
-        package         => $self->{'spec'},
+        package         => $self->{'package'},
         file_02packages => $self->{'file_02packages'},
         no_deps         => $self->{'opt'}{'no_deps'},
         requires_only   => $self->{'opt'}{'requires_only'},
@@ -232,10 +232,10 @@ sub _validate_args_add {
 
     if ( $cpanfile ) {
         @{ $self->{'args'} }
-            and $self->usage_error( "You can't have both a 'spec' and a 'cpanfile'\n" );
+            and $self->usage_error( "You can't have both a 'package' and a 'cpanfile'\n" );
         $self->{'cpanfile'} = $cpanfile;
     } else {
-        $self->_read_set_spec_str;
+        $self->_read_set_package_str;
     }
 
     # TODO: config ???
@@ -249,26 +249,26 @@ sub _validate_args_add {
 
 sub _validate_args_remove {
     my $self = shift;
-    $self->_read_set_spec_str;
+    $self->_read_set_package_str;
 }
 
 sub _validate_args_remove_parcel {
     my $self = shift;
-    $self->_read_set_spec_str;
+    $self->_read_set_package_str;
 }
 
 sub _validate_args_dependency {
     my $self = shift;
     my $opt  = $self->{'opt'};
 
-    # spec
-    $self->_read_set_spec_str;
+    # package
+    $self->_read_set_package_str;
 
     # pakket manage add-deps perl/Dancer2=0.9 --phase runtime --on perl/Moo=2
     defined $opt->{$_} or $self->usage_error("Missing argument $_")
         for qw< phase on >;
 
-    my $dep = $self->_read_spec_str( $opt->{'on'} );
+    my $dep = $self->_read_package_str( $opt->{'on'} );
 
     defined $dep->{'version'}
         or $self->usage_error( "Invalid dependency: missing version" );
@@ -279,15 +279,15 @@ sub _validate_args_dependency {
 
 sub _validate_args_show {
     my $self = shift;
-    $self->_read_set_spec_str;
+    $self->_read_set_package_str;
 }
 
 sub _validate_args_show_deps {
     my $self = shift;
-    $self->_read_set_spec_str;
+    $self->_read_set_package_str;
 }
 
-sub _read_spec_str {
+sub _read_package_str {
     my ( $self, $spec_str ) = @_;
 
     my $spec;
@@ -306,13 +306,13 @@ sub _read_spec_str {
     return $spec;
 }
 
-sub _read_set_spec_str {
+sub _read_set_package_str {
     my $self = shift;
 
     my $spec_str = shift @{ $self->{'args'} };
     $spec_str or $self->usage_error( "Must provide a package id (category/name=version:release)" );
 
-    $self->{'spec'} = $self->_read_spec_str($spec_str);
+    $self->{'package'} = $self->_read_package_str($spec_str);
 }
 
 1;

--- a/lib/Pakket/CLI/Command/manage.pm
+++ b/lib/Pakket/CLI/Command/manage.pm
@@ -218,6 +218,10 @@ sub _validate_arg_cache_dir {
             or $self->usage_error( "cache-dir: $cache_dir doesn't exist\n" );
         $self->{'cache_dir'} = $cache_dir;
     }
+    if ($self->{'opt'}{'is_local'} and !$self->{'cache_dir'}) {
+        $self->usage_error( "Flag --is-local doesn't make sense without --cache-dir.\n".
+                            "Please specify directory with sources --cache-dir.\n");
+    }
 }
 
 sub _validate_args_add {

--- a/lib/Pakket/Manager.pm
+++ b/lib/Pakket/Manager.pm
@@ -294,18 +294,8 @@ sub _gen_scaffolder_perl {
 
     if ( $self->cpanfile ) {
         $params{'cpanfile'} = $self->cpanfile;
-
     } else {
-        my $name = $self->package->name;
-        my $version = $self->package->version;
-        if (defined $version && $self->package->$_isa('Pakket::PackageQuery')) {
-            # hack to pass exact version in prereq syntax
-            # add '==' before number of version
-            $version =~ s/^/== /;
-        }
-
-        $params{'module'}  = $name;
-        $params{'version'} = $version;
+        $params{'module'} = $self->package;
     }
 
     $self->cache_dir

--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -168,11 +168,9 @@ sub BUILDARGS {
         unless $module xor $cpanfile;
 
     if ( $module ) {
-        # hack to pass exact version in prereq syntax
-        # add '==' before number of version
         my $version = $module->version
-                        ? "== " . $module->version
-                        : ">= 0";
+                        ? "== " . $module->version  # exact version
+                        : ">= 0";                   # latest version
 
         my ( $phase, $type   ) = delete @args{qw< phase type >};
         $args{'modules'} =
@@ -189,6 +187,7 @@ sub BUILDARGS {
                 'cpanfile' => $cpanfile
             )->prereq_specs;
     }
+
     return \%args;
 }
 

--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -181,11 +181,17 @@ sub BUILDARGS {
         unless $module xor $cpanfile;
 
     if ( $module ) {
-        my ( $version, $phase, $type ) = delete @args{qw< version phase type >};
+        # hack to pass exact version in prereq syntax
+        # add '==' before number of version
+        my $version = $module->version
+                        ? "== " . $module->version
+                        : ">= 0";
+
+        my ( $phase, $type   ) = delete @args{qw< phase type >};
         $args{'modules'} =
             Pakket::Scaffolder::Perl::Module->new(
-                'name' => $module,
-                ( version => $version )x!! defined $version,
+                'name'    => $module->name,
+                'version' => $version,
                 ( phase   => $phase   )x!! defined $phase,
                 ( type    => $type    )x!! defined $type,
             )->prereq_specs;


### PR DESCRIPTION
1. Add releases in Scaffolder.

2. Rename 'spec'->'package' in CLI/manage  …
There is one definition 'spec' for spec repo and another 'spec' for package.
Using the same name for two different things is confusing.

3. Get rid of Pakket::Requirement in manager.pm
Pakket::Requirement duplicates functionality of Pakket::PackageQuery.

4. Check existence of --cache-dir if using flag --is-local  …
Using flag --is-local doesn't make sense without specifying  directory
with sources --cache-dir.

5. Move code for getting path into get_source_archive_path  …
There were two different blocks of code doing the same thing -
find path to archive with sources.