### PR TITLE
Don't check version when adding/removing dependencies

### DIFF
--- a/lib/Pakket/Manager.pm
+++ b/lib/Pakket/Manager.pm
@@ -227,8 +227,7 @@ sub _package_dependency_edit {
 
     my ( $category, $phase ) = @{$dependency}{qw< category phase >};
 
-    my $dep_exists = ( defined $spec->{'Prereqs'}{$category}{$phase}{$dep_name}
-                           and $spec->{'Prereqs'}{$category}{$phase}{$dep_name}{'version'} eq $dep_version );
+    my $dep_exists = ( defined $spec->{'Prereqs'}{$category}{$phase}{$dep_name} );
 
     my $name = $self->package->name;
 


### PR DESCRIPTION
Don't check version when adding/removing dependencies, just check existence of
dependency by name.

Checking versions had two bad behaviours:
- for add-dependency, if dependency exists with different version,
    it doesn't recognize it and just silently 'rewrites' version
- for remove-dependency, we have to specify exact version to remove it,
    which is inconvenient, we should allow users to do it just by name,
    without specifying version.