### PR TITLE
Add category-level package exclude

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -8,7 +8,7 @@ version 1.1
 
 # DESCRIPTION
 
-Pakket is a meta-packaging system that allows you to manage your system
+Pakket is a meta-packaging system that allows you to manage
 dependencies. It works by trying to avoid work.
 
 ## What can you do with Pakket?

--- a/dist.ini
+++ b/dist.ini
@@ -26,7 +26,7 @@ version = 1.1
 [MetaProvides::Package]
 
 ; Crashes with FatPacker
-;[MinimumPerlFast]
+[MinimumPerlFast]
 
 [@Filter]
 -bundle = @Basic
@@ -75,7 +75,7 @@ match = dist.ini
 [Prereqs::FromCPANfile]
 
 [ExecDir]
-dir = script
+dir = bin
 
 [ShareDir]
 dir = share
@@ -87,5 +87,5 @@ dir = share
 filename = README.mkdn
 
 ; Clears our local tests in t/
-;[FatPacker]
-;script = bin/pakket
+[FatPacker]
+script = bin/pakket

--- a/lib/Pakket/Builder.pm
+++ b/lib/Pakket/Builder.pm
@@ -9,6 +9,7 @@ use File::Copy::Recursive     qw< dircopy     >;
 use Algorithm::Diff::Callback qw< diff_hashes >;
 use Types::Path::Tiny         qw< Path >;
 use Log::Any                  qw< $log >;
+use List::Util                qw< first >;
 use version 0.77;
 
 use Pakket::Log qw< log_success log_fail >;
@@ -277,12 +278,9 @@ sub run_build {
     my $bootstrap_prereqs = $params->{'bootstrapping_2_deps_only'}    || 0;
     my $full_name         = $prereq->full_name;
 
-    # FIXME: GH #29
-    if ( $prereq->category eq 'perl' ) {
-        # XXX: perl_mlb is a MetaCPAN bug
-        $prereq->name eq 'perl_mlb' and return;
-        $prereq->name eq 'perl'     and return;
-    }
+    first { $prereq->name eq $_ }
+        @{ $self->builders->{ $prereq->category }->exclude_packages }
+        and return;
 
     if ( ! $bootstrap_prereqs and defined $self->is_built->{$full_name} ) {
         $log->debug(

--- a/lib/Pakket/Builder/Perl.pm
+++ b/lib/Pakket/Builder/Perl.pm
@@ -11,6 +11,11 @@ use Carp ();
 
 with qw<Pakket::Role::Builder>;
 
+has '+exclude_packages' => (
+    # 'perl_mlb' is a MetaCPAN bug
+    'default' => [ qw< perl perl_mlb > ],
+);
+
 sub build_package {
     my ( $self, $package, $build_dir, $prefix, $config_flags, $build_flags ) = @_;
 

--- a/lib/Pakket/Role/Builder.pm
+++ b/lib/Pakket/Role/Builder.pm
@@ -8,6 +8,12 @@ with qw< Pakket::Role::RunCommand >;
 
 requires qw< build_package >;
 
+has 'exclude_packages' => (
+    'is'      => 'ro',
+    'isa'     => 'ArrayRef',
+    'default' => sub { [] },
+);
+
 no Moose::Role;
 
 1;


### PR DESCRIPTION
A category-based builder can now override the 'exclude_packages' attribute default value and provide a list of package names it would like to ignore and not 

This closes GH #29.
