### PR TITLE
Add category-level package exclude list:

### DIFF
--- a/lib/Pakket/Builder.pm
+++ b/lib/Pakket/Builder.pm
@@ -9,6 +9,7 @@ use File::Copy::Recursive     qw< dircopy     >;
 use Algorithm::Diff::Callback qw< diff_hashes >;
 use Types::Path::Tiny         qw< Path >;
 use Log::Any                  qw< $log >;
+use List::Util                qw< first >;
 use version 0.77;
 
 use Pakket::Log qw< log_success log_fail >;
@@ -277,12 +278,9 @@ sub run_build {
     my $bootstrap_prereqs = $params->{'bootstrapping_2_deps_only'}    || 0;
     my $full_name         = $prereq->full_name;
 
-    # FIXME: GH #29
-    if ( $prereq->category eq 'perl' ) {
-        # XXX: perl_mlb is a MetaCPAN bug
-        $prereq->name eq 'perl_mlb' and return;
-        $prereq->name eq 'perl'     and return;
-    }
+    first { $prereq->name eq $_ }
+        @{ $self->builders->{ $prereq->category }->exclude_packages }
+        and return;
 
     if ( ! $bootstrap_prereqs and defined $self->is_built->{$full_name} ) {
         $log->debug(

--- a/lib/Pakket/Builder.pm
+++ b/lib/Pakket/Builder.pm
@@ -9,7 +9,6 @@ use File::Copy::Recursive     qw< dircopy     >;
 use Algorithm::Diff::Callback qw< diff_hashes >;
 use Types::Path::Tiny         qw< Path >;
 use Log::Any                  qw< $log >;
-use List::Util                qw< first >;
 use version 0.77;
 
 use Pakket::Log qw< log_success log_fail >;
@@ -278,8 +277,7 @@ sub run_build {
     my $bootstrap_prereqs = $params->{'bootstrapping_2_deps_only'}    || 0;
     my $full_name         = $prereq->full_name;
 
-    first { $prereq->name eq $_ }
-        @{ $self->builders->{ $prereq->category }->exclude_packages }
+    $self->builders->{ $prereq->category }->exclude_packages->{ $prereq->name }
         and return;
 
     if ( ! $bootstrap_prereqs and defined $self->is_built->{$full_name} ) {

--- a/lib/Pakket/Builder/Perl.pm
+++ b/lib/Pakket/Builder/Perl.pm
@@ -12,8 +12,14 @@ use Carp ();
 with qw<Pakket::Role::Builder>;
 
 has '+exclude_packages' => (
-    # 'perl_mlb' is a MetaCPAN bug
-    'default' => [ qw< perl perl_mlb > ],
+    'default' => sub {
+        return {
+            'perl'     => 1,
+
+            # MetaCPAN bug
+            'perl_mlb' => 1,
+        };
+    },
 );
 
 sub build_package {

--- a/lib/Pakket/Builder/Perl.pm
+++ b/lib/Pakket/Builder/Perl.pm
@@ -11,6 +11,11 @@ use Carp ();
 
 with qw<Pakket::Role::Builder>;
 
+has '+exclude_packages' => (
+    # 'perl_mlb' is a MetaCPAN bug
+    'default' => [ qw< perl perl_mlb > ],
+);
+
 sub build_package {
     my ( $self, $package, $build_dir, $prefix, $config_flags, $build_flags ) = @_;
 

--- a/lib/Pakket/Role/Builder.pm
+++ b/lib/Pakket/Role/Builder.pm
@@ -8,6 +8,12 @@ with qw< Pakket::Role::RunCommand >;
 
 requires qw< build_package >;
 
+has 'exclude_packages' => (
+    'is'      => 'ro',
+    'isa'     => 'ArrayRef',
+    'default' => sub { [] },
+);
+
 no Moose::Role;
 
 1;

--- a/lib/Pakket/Role/Builder.pm
+++ b/lib/Pakket/Role/Builder.pm
@@ -10,8 +10,8 @@ requires qw< build_package >;
 
 has 'exclude_packages' => (
     'is'      => 'ro',
-    'isa'     => 'ArrayRef',
-    'default' => sub { [] },
+    'isa'     => 'HashRef',
+    'default' => sub { +{} },
 );
 
 no Moose::Role;


### PR DESCRIPTION
A category-based builder can now override the 'exclude_packages' attribute default value and provide a list of package names it would like to ignore and not build.

This closes GH #29.

(Resubmitted because GH is silly.)