### PR TITLE
 Don't replace symlinks with actual copies of files when creating parcel

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,7 @@ requires 'IO::Prompt::Tiny';
 requires 'CPAN::DistnameInfo';
 requires 'CPAN::Meta::Requirements', '>= 2.140';
 requires 'File::Basename';
+requires 'File::chdir';
 requires 'File::Copy::Recursive';
 requires 'File::Find';
 requires 'File::HomeDir';

--- a/lib/Pakket/Bundler.pm
+++ b/lib/Pakket/Bundler.pm
@@ -4,6 +4,7 @@ package Pakket::Bundler;
 use Moose;
 use MooseX::StrictConstructor;
 use JSON::MaybeXS;
+use File::chdir;
 use File::Spec;
 use Carp              qw< croak >;
 use Path::Tiny        qw< path >;
@@ -81,11 +82,10 @@ sub bundle {
             my $new_symlink = $self->_rebase_build_to_output_dir(
                 $build_dir, $files->{$orig_file},
             );
-
-            my $previous_dir = Path::Tiny->cwd;
-            chdir $new_fullname->parent;
-            symlink $new_symlink, $new_fullname->basename;
-            chdir $previous_dir;
+            {
+                local $CWD = $new_fullname->parent;
+                symlink $new_symlink, $new_fullname->basename;
+            }
         }
     }
 


### PR DESCRIPTION
Don't replace symlinks with actual copies of files when creating parcel
The Archive::Tar::Wrapper, which we used to create parcels,
can't correctly operate with symlinks and replaces them with actual
copies of files. This behavior breaks the way how system operate with
native libraries. System uses symlinks to point to the current version
of library. So, we need symlinks.

I replaced Archive::Tar::Wrapper with Archive::Tar to fix that.

By the way some cleanup:
Replace chdir with File::chdir
This is small cleanup. The benefits of using File::chdir compare with
regular chdir() is that it supports 'local' and don't need to reset chdir
back and forth. Also it is not so global.