### PR TITLE
Support source url in custom specs

### DIFF
--- a/lib/Pakket/Package.pm
+++ b/lib/Pakket/Package.pm
@@ -16,6 +16,11 @@ has [ qw< name category version release > ] => (
     'required' => 1,
 );
 
+has 'source' => (
+    'is'       => 'ro',
+    'isa'      => 'Maybe[Str]',
+);
+
 has 'is_bootstrap' => (
     'is'      => 'ro',
     'isa'     => 'Bool',
@@ -93,7 +98,7 @@ sub phase_prereqs {
 sub spec {
     my $self = shift;
 
-    return +{
+    my $result = {
         'Package' => {
             # This is so we don't see is_bootstrap in spec
             # if not required -- SX
@@ -106,6 +111,9 @@ sub spec {
 
         map +( $_ => $self->$_ ), qw<build_opts bundle_opts>,
     };
+    $result->{Package}{source} = $self->{source} if $self->{source};
+
+    return $result;
 }
 
 sub new_from_spec {

--- a/lib/Pakket/Scaffolder/Perl.pm
+++ b/lib/Pakket/Scaffolder/Perl.pm
@@ -290,7 +290,7 @@ sub add_source_for_package {
         return;
     }
 
-    my $download_url = $self->rewrite_download_url( $release_info->{'download_url'} );
+    my $download_url = $self->rewrite_download_url( $release_info->{'download_url'}, $package );
 
     if ( $self->_has_cache_dir ) {
         my $from_file;
@@ -683,7 +683,8 @@ sub get_all_releases_for_distribution {
 }
 
 sub rewrite_download_url {
-    my ( $self, $download_url ) = @_;
+    my ( $self, $download_url, $package ) = @_;
+    return $package->{source} if $package->{source};
     my $rewrite = $self->config->{'perl'}{'metacpan'}{'rewrite_download_url'};
     return $download_url unless is_hashref($rewrite);
     my ( $from, $to ) = @{$rewrite}{qw< from to >};


### PR DESCRIPTION
* use 'source' parameter in spec file to download sources
* when 'source' is set in custom spec it will be saved in pakket spec