### PR TITLE
Add option read_only for web frontend

### DIFF
--- a/lib/Pakket/Web/Repo.pm
+++ b/lib/Pakket/Web/Repo.pm
@@ -86,6 +86,8 @@ sub create {
             };
         };
 
+        return if ($args->{'read_only'});
+
         prefix '/store' => sub {
             # There is no body to check, because the body is JSON content
             # So we manually decode and check


### PR DESCRIPTION
To be able to restrict access for web repositories.

{
  "repositories" : [    
    {               
        "path"    : "/spec",
        "type"    : "spec", 
        "backend" : [ "File", "directory", "/var/spec",   "file_extension", "ini"  ],
        "read_only" : "true"
    },              
  ]
}