### PR TITLE
Add support for git sources in specs

### DIFF
--- a/lib/Pakket/Downloader.pm
+++ b/lib/Pakket/Downloader.pm
@@ -1,0 +1,116 @@
+package Pakket::Downloader;
+# ABSTRACT: Download sources supporting different protocols
+
+use Moose;
+use MooseX::StrictConstructor;
+use Archive::Tar;
+use File::chdir;
+use Carp              qw< croak >;
+use Path::Tiny        qw< path >;
+use Types::Path::Tiny qw< Path >;
+use Log::Any          qw< $log >;
+
+has 'package_name' => (
+    is       => 'ro',
+    isa      => 'Str',
+    required => 1,
+);
+
+has 'url' => (
+    is       => 'ro',
+    isa      => 'Str',
+    required => 1,
+);
+
+has 'tempdir' => (
+    is      => 'ro',
+    isa     => Path,
+    coerce  => 1,
+    lazy    => 1,
+    default => \&_default_tempdir,
+);
+
+sub to_file {
+    my ($self) = @_;
+
+    $log->debugf( "Downloaging file from %s", $self->url );
+    return $self->download_to_file;
+}
+
+sub to_dir {
+    my ($self) = @_;
+
+    $log->debugf( "Downloaging and extracting from %s", $self->url );
+    return $self->download_to_dir;
+}
+
+sub _default_tempdir {
+    my ($self) = @_;
+    return Path::Tiny->tempdir( 'CLEANUP' => 1 );
+}
+
+sub _pack {
+    my ($self, $base_path) = @_;
+
+    my @files;
+    $base_path->visit(
+        sub {
+            my $path = shift;
+            $path->is_file or return;
+
+            push @files, $path;
+        },
+        { 'recurse' => 1 },
+    );
+    @files = map {$_->relative($base_path)->stringify} @files;
+
+    my $arch = Archive::Tar->new();
+    {
+        local $CWD = $base_path;
+        $arch->add_files(@files);
+    }
+
+    my $file = Path::Tiny->tempfile();
+    $log->debug("Writing archive as $file");
+    $arch->write( $file->stringify, COMPRESS_GZIP );
+
+    return $file;
+}
+
+sub _unpack {
+    my ( $self, $file ) = @_;
+
+    my $archive = Archive::Any->new($file);
+    if ( $archive->is_naughty ) {
+        Carp::croak( $log->critical("Suspicious ($file)") );
+    }
+
+    my $dir = Path::Tiny->tempdir( 'CLEANUP' => 1 );
+    $archive->extract($dir);
+
+    # Determine if this is a directory in and of itself
+    # or whether it's just a bunch of files
+    # (This is what Archive::Any refers to as "impolite")
+    # It has to be done manually, because the list of files
+    # from an archive might return an empty directory listing
+    # or none, which confuses us
+    my @files = $dir->children();
+    if ( @files == 1 && $files[0]->is_dir ) {
+        # Polite
+        my @inner = $files[0]->children();
+        foreach my $infile (@inner) {
+            $infile->move(path($dir, $infile->basename));
+        }
+        rmdir $files[0];
+    }
+
+    # Is impolite, meaning it's just a bunch of files
+    # (or a single file, but still)
+    return $dir;
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;
+
+__END__

--- a/lib/Pakket/Downloader/ByUrl.pm
+++ b/lib/Pakket/Downloader/ByUrl.pm
@@ -1,0 +1,24 @@
+package Pakket::Downloader::ByUrl;
+
+use Pakket::Downloader::Git;
+use Pakket::Downloader::Http;
+use Pakket::Downloader::File;
+use Carp        qw< croak >;
+use Log::Any    qw< $log >;
+
+sub create {
+    my ($package_name, $url) = @_;
+
+    $log->debugf("Downloading sources for %s (%s)", $package_name, $url);
+    if ($url =~ m/^http/) {
+        return Pakket::Downloader::Http->new(package_name => $package_name, url => $url);
+    } elsif ($url =~ m/^git/) {
+        return Pakket::Downloader::Git->new(package_name => $package_name, url => $url);
+    } elsif ($url =~ m/^file/) {
+        return Pakket::Downloader::File->new(package_name => $package_name, url => $url);
+    } else {
+        Carp::croak($log->critical("Invalid sources url ($url)"));
+    }
+}
+
+1;

--- a/lib/Pakket/Downloader/File.pm
+++ b/lib/Pakket/Downloader/File.pm
@@ -1,0 +1,34 @@
+package Pakket::Downloader::File;
+# ABSTRACT: Local downloader specialisation
+
+use Moose;
+use MooseX::StrictConstructor;
+use Path::Tiny        qw< path >;
+use Types::Path::Tiny qw< Path >;
+use Carp              qw< croak >;
+use Log::Any          qw< $log >;
+use namespace::autoclean;
+
+extends qw< Pakket::Downloader >;
+
+sub BUILD {
+    my ($self) = @_;
+    (undef, $self->{url}) = split('file://', $self->url);
+}
+
+sub download_to_file {
+    my ($self) = @_;
+
+    return path($self->url);
+}
+
+sub download_to_dir {
+    my ($self) = @_;
+
+    my $file = $self->download_to_file();
+    return $self->_unpack($file);
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/Pakket/Downloader/Git.pm
+++ b/lib/Pakket/Downloader/Git.pm
@@ -1,0 +1,47 @@
+package Pakket::Downloader::Git;
+# ABSTRACT: Git downloader specialisation
+
+use Moose;
+use MooseX::StrictConstructor;
+use Path::Tiny          qw< path >;
+use Types::Path::Tiny   qw< Path >;
+use Carp                qw< croak >;
+use Log::Any            qw< $log >;
+use Git::Wrapper;
+use namespace::autoclean;
+
+extends qw< Pakket::Downloader >;
+
+has 'commit' => (
+    is       => 'ro',
+    isa      => 'Str',
+);
+
+sub BUILD {
+    my ($self) = @_;
+
+    ($self->{url}, $self->{commit}) = split('#', $self->url);
+}
+
+sub download_to_file {
+    my ($self) = @_;
+
+    $self->download_to_dir($self->tempdir->absolute);
+    return $self->_pack($self->tempdir->absolute);
+}
+
+sub download_to_dir {
+    my ($self) = @_;
+
+    $log->debugf( "Processing git repo %s with commit %s", $self->url, $self->commit // '' );
+    my $repo = Git::Wrapper->new($self->tempdir->absolute);
+    $repo->clone($self->url, $self->tempdir->absolute);
+    $repo->checkout(qw/--force --no-track -B pakket/, $self->commit) if $self->commit;
+    system('rm -rf ' . $self->tempdir->absolute . '/.git');
+
+    return $self->tempdir->absolute;
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/Pakket/Downloader/Http.pm
+++ b/lib/Pakket/Downloader/Http.pm
@@ -1,0 +1,39 @@
+package Pakket::Downloader::Http;
+# ABSTRACT: Http downloader specialisation
+
+use Moose;
+use MooseX::StrictConstructor;
+use Path::Tiny          qw< path >;
+use Types::Path::Tiny   qw< Path >;
+use Carp                qw< croak >;
+use Log::Any            qw< $log >;
+use namespace::autoclean;
+
+extends qw< Pakket::Downloader >;
+
+sub BUILD {
+    my ($self) = @_;
+}
+
+sub download_to_file {
+    my ($self) = @_;
+
+    my $file = Path::Tiny->tempfile;
+    my $http = HTTP::Tiny->new();
+    my $result = $http->mirror($self->url, $file, {headers => {'If-Modified-Since' => 'Thu, 1 Jan 1970 01:00:00 GMT'}});
+    if (!$result->{success}) {
+        Carp::croak( "Can't download sources for ", $self->package_name );
+    }
+    return $file;
+}
+
+sub download_to_dir {
+    my ($self) = @_;
+
+    my $file = $self->download_to_file();
+    return $self->_unpack($file);
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/Pakket/Manager.pm
+++ b/lib/Pakket/Manager.pm
@@ -334,7 +334,8 @@ sub _gen_scaffolder_perl {
     if ( $self->cpanfile ) {
         $params{'cpanfile'} = $self->cpanfile;
     } elsif ( $self->custom_spec ) {
-        $params{'custom_spec'} = $self->custom_spec;
+        my $name = $self->{custom_spec}{Package}{name};
+        $params{custom_spec}{$name} = $self->custom_spec;
     } else {
         $params{'module'} = $self->package;
     }


### PR DESCRIPTION
* specs now support git and http sources
* if sources is set in spec - they will be used instead of cpan sources for this package
* small scafforlder refactoring and removing download related code to separate files