### PR TITLE
Return failure when requesting to install missing packages

### DIFF
--- a/lib/Pakket/Installer.pm
+++ b/lib/Pakket/Installer.pm
@@ -81,7 +81,7 @@ sub install {
     @packages or return;
 
     if (!$self->check_packages_in_parcel_repo(\@packages)) {
-        return;
+        return 1;
     }
 
     my $installer_cache = {};


### PR DESCRIPTION
If a user requests to install packages missing from the repository,
we're currently only printing the error message, and exiting with code 0
(success). We should exit with a positive code to denote error.