### PR TITLE
Support comments in package files

### DIFF
--- a/lib/Pakket/CLI/Command/install.pm
+++ b/lib/Pakket/CLI/Command/install.pm
@@ -66,6 +66,7 @@ sub _determine_packages {
 
     my @packages;
     foreach my $package_str (@package_strs) {
+        next if $package_str =~ /^#/;
         my ( $pkg_cat, $pkg_name, $pkg_version, $pkg_release ) =
             $package_str =~ PAKKET_PACKAGE_SPEC();
 


### PR DESCRIPTION
Hi! 

I'd like to create pakket package lists in projects for people with some comments explaining how they should use them. This would be best accomplished with some inline comments on how to add stuff, and where to find more packages.

I'm totally fine if we prefer something other than '#' as the comment marker, but I think most config formats should support comments, so I'd be eager to see them in pakket.

For example:
in `pakket.list` or similar:
```
# Add your package dependencies here.
# E.g.:
# perl/Dancer2
```

Thanks!