### PR TITLE
Enable non atomic installs

### DIFF
--- a/lib/Pakket/CLI/Command/install.pm
+++ b/lib/Pakket/CLI/Command/install.pm
@@ -46,6 +46,10 @@ sub _determine_config {
         $config->{'install_dir'} = $opt->{'to'};
     }
 
+    if ( $opt->{'no_atomic'} ) {
+        $config->{'atomic'} = 0;
+    }
+
     if ( !$config->{'install_dir'} ) {
         $self->usage_error(
             "Missing where to install\n"
@@ -91,6 +95,7 @@ sub opt_spec {
             'from=s',
             'directory to install the packages from',
         ],
+        [ 'no-atomic',      "don't use atomic operations" ],
         [ 'input-file=s',   'install everything listed in this file' ],
         [ 'config|c=s',     'configuration file' ],
         [ 'log-file=s',     'log file' ],
@@ -116,6 +121,7 @@ sub validate_args {
     $opt->{'packages'}   = $self->_determine_packages( $opt, $args );
 
     $opt->{'config'}{'env'}{'cli'} = 1;
+    $opt->{'config'}{'atomic'} //= 1;
 }
 
 sub execute {
@@ -138,6 +144,7 @@ sub _create_installer {
 
     return Pakket::Installer->new(
         'config'          => $opt->{'config'},
+        'atomic'          => $opt->{'config'}{'atomic'},
         'pakket_dir'      => $opt->{'config'}{'install_dir'},
         'force'           => $opt->{'force'},
         'ignore_failures' => $opt->{'ignore_failures'},


### PR DESCRIPTION
Pakket currently uses a simple and effective system to install all
dependencies atomically. It involves copying the entire installation
directory to a new working directory, and later changing symlinks.

The issue with that is that with Docker images, it's really wasteful. It
creates a new layer with the entire size of the installation, even if a
single small module was installed or upgraded.

This patch creates a configuration option, `atomic`, and a command-line
option for `pakket install`, `--no-atomic`, which control this
behaviour.

By default, nothing changes, so atomic installations are always on
unless explicitly requested with:

In /etc/pakket.json:

```json
{
    ...
    "atomic": 0
}
```

Or:

```
$ pakket install --no-atomic ...
```